### PR TITLE
Adding/Updating License for the Supervisor BYOI source code

### DIFF
--- a/images/tkg/Dockerfile
+++ b/images/tkg/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 FROM photon:3.0
 
 ARG PACKER_VERSION=1.8.3

--- a/images/tkg/Makefile
+++ b/images/tkg/Makefile
@@ -1,3 +1,5 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 
 SHELL := /usr/bin/env bash -o errexit -o pipefail -o nounset
 MAKEFLAGS += -s

--- a/images/tkg/ansible/defaults/main.yml
+++ b/images/tkg/ansible/defaults/main.yml
@@ -1,3 +1,5 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 ---
 #photon does not have backward compatibility for legacy distro behavior for sysctl.conf by default
 #as it uses systemd-sysctl. set this var so we can use for sysctl conf file value.

--- a/images/tkg/ansible/tasks/common.yml
+++ b/images/tkg/ansible/tasks/common.yml
@@ -1,3 +1,5 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 ---
 - name: Configure /etc/sysctl.d/80-bridged-net-traffic.conf
   copy:
@@ -36,7 +38,6 @@
     dest: /etc/crictl.yaml
     mode: 0644
 
-# Fix for GCM-6896
 - name: Replace containerd systemd file
   copy:
     src: etc/systemd/system/containerd.service
@@ -122,7 +123,6 @@
   retries: 5
   delay: 3
 
-# To support https://gitlab.eng.vmware.com/core-build/guest-cluster-controller/-/merge_requests/703
 - name: Disable kubelet and containerd service
   systemd:
     name: "{{ item }}"

--- a/images/tkg/ansible/tasks/disable_pwd_rotation.yml
+++ b/images/tkg/ansible/tasks/disable_pwd_rotation.yml
@@ -1,3 +1,5 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 - name: Disable password expiry
   ansible.builtin.shell: sed -i 's/^PASS_MAX_DAYS.*$/PASS_MAX_DAYS -1/g' /etc/login.defs
   args:

--- a/images/tkg/ansible/tasks/iptables.yml
+++ b/images/tkg/ansible/tasks/iptables.yml
@@ -1,3 +1,5 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 ---
 - name: Copy iptables rules file
   copy:

--- a/images/tkg/ansible/tasks/main.yml
+++ b/images/tkg/ansible/tasks/main.yml
@@ -1,3 +1,5 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 ---
 - import_tasks: common.yml
 

--- a/images/tkg/ansible/tasks/photon.yml
+++ b/images/tkg/ansible/tasks/photon.yml
@@ -1,5 +1,6 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 ---
-# Needed only for Photon Refer: https://bugzilla.eng.vmware.com/show_bug.cgi?id=2751785#c10
 - name: Create afterdbus.conf
   copy:
     src: files/etc/systemd/system/vmtoolsd.service.d/afterdbus.conf

--- a/images/tkg/ansible/tasks/retag_images.yml
+++ b/images/tkg/ansible/tasks/retag_images.yml
@@ -1,16 +1,5 @@
-# Copyright 2021 The Kubernetes Authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-# http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 ---
 - name: Retag Container Images
   script: files/scripts/image_retag.py --k8sSemver {{ kubernetes_semver }} --dockerVersion {{ dockerVersion }} --family "{{ ansible_os_family }}"

--- a/images/tkg/ansible/tasks/ubuntu.yml
+++ b/images/tkg/ansible/tasks/ubuntu.yml
@@ -1,3 +1,5 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 ---
 - name: Modify /bin/sh to point to bash instead of dash
   shell: "{{ item }}"

--- a/images/tkg/ansible/tasks/ubuntu_hack.yml
+++ b/images/tkg/ansible/tasks/ubuntu_hack.yml
@@ -1,5 +1,7 @@
-#Conditionally defer cloud-init to second boot, allowing vmtools customization on first boot and reboot
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 ---
+#Conditionally defer cloud-init to second boot, allowing vmtools customization on first boot and reboot
 - name: Adding "disable_vmware_customization= true" to /etc/cloud/cloud.cfg
   lineinfile:
     line: "disable_vmware_customization: true"

--- a/images/tkg/ansible/tasks/va_hardening.yml
+++ b/images/tkg/ansible/tasks/va_hardening.yml
@@ -1,3 +1,5 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 ---
 - name: Install rpm-build package
   command: tdnf install rpm-build -y

--- a/images/tkg/build-ova.sh
+++ b/images/tkg/build-ova.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 
 set -e
 set -x

--- a/images/tkg/goss/goss-command.yaml
+++ b/images/tkg/goss/goss-command.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 command:
   containerd --version | awk -F' ' '{print substr($3,2); }':
     exit-status: 0

--- a/images/tkg/goss/goss-kernel-params.yaml
+++ b/images/tkg/goss/goss-kernel-params.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 kernel-param:
   net.bridge.bridge-nf-call-iptables:
     value: "1"

--- a/images/tkg/goss/goss-package.yaml
+++ b/images/tkg/goss/goss-package.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 package:
   cloud-init:
     installed: true

--- a/images/tkg/goss/goss-service.yaml
+++ b/images/tkg/goss/goss-service.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 service:
   containerd:
     enabled: false

--- a/images/tkg/goss/goss-vars.yaml
+++ b/images/tkg/goss/goss-vars.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 # Everything from here to the TKG section should be kept in sync
 # with upstream settings

--- a/images/tkg/goss/goss.yaml
+++ b/images/tkg/goss/goss.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 gossfile:
   goss-command.yaml: {}
   goss-kernel-params.yaml: {}

--- a/images/tkg/hack/make-helpers/build-node-image.sh
+++ b/images/tkg/hack/make-helpers/build-node-image.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 set -e
 
 source $(dirname "${BASH_SOURCE[0]}")/utils.sh

--- a/images/tkg/hack/make-helpers/clean-containers.sh
+++ b/images/tkg/hack/make-helpers/clean-containers.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 
 set -e
 source $(dirname "${BASH_SOURCE[0]}")/utils.sh

--- a/images/tkg/hack/make-helpers/clean-image-artifacts.sh
+++ b/images/tkg/hack/make-helpers/clean-image-artifacts.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 
 set -e
 source $(dirname "${BASH_SOURCE[0]}")/utils.sh

--- a/images/tkg/hack/make-helpers/list-versions.sh
+++ b/images/tkg/hack/make-helpers/list-versions.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 
 set -e
 source $(dirname "${BASH_SOURCE[0]}")/utils.sh

--- a/images/tkg/hack/make-helpers/make-help.sh
+++ b/images/tkg/hack/make-helpers/make-help.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 
 set -o errexit
 set -o nounset

--- a/images/tkg/hack/make-helpers/run-artifacts-container.sh
+++ b/images/tkg/hack/make-helpers/run-artifacts-container.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 
 set -e
 source $(dirname "${BASH_SOURCE[0]}")/utils.sh

--- a/images/tkg/hack/make-helpers/utils.sh
+++ b/images/tkg/hack/make-helpers/utils.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 
 # Terminal colors
 red='\033[0;31m'

--- a/images/tkg/hack/tkgs-image-build-ova.py
+++ b/images/tkg/hack/tkgs-image-build-ova.py
@@ -1,18 +1,7 @@
 #!/usr/bin/env python3
 
-# Copyright 2019 The Kubernetes Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
 
 ################################################################################
 # usage: image-build-ova.py [FLAGS] ARGS

--- a/images/tkg/hack/tkgs_ovf_template.xml
+++ b/images/tkg/hack/tkgs_ovf_template.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2023 VMware, Inc.
+    SPDX-License-Identifier: MPL-2.0
+-->
 <Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:cim="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <References>
         <File ovf:id="file1" ovf:href="${DISK_NAME}" ovf:size="${STREAM_DISK_SIZE}"/>

--- a/images/tkg/scripts/tkg_byoi.py
+++ b/images/tkg/scripts/tkg_byoi.py
@@ -1,3 +1,6 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 import argparse
 import json
 import os

--- a/images/tkg/scripts/utkg_custom_ovf_properties.py
+++ b/images/tkg/scripts/utkg_custom_ovf_properties.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 import argparse
 import base64
 import json


### PR DESCRIPTION
Changes:
- Updating the LICENSE and NOTICE files with the files attached to [OSS Ticket](https://upstreamcontrib.eng.vmware.com/oss/#/upstreamcontrib/project/4147525)
- Added the Copyright and license headers to the source code. (Please find the sample below)
```
# Copyright 2023 VMware, Inc.
# SPDX-License-Identifier: MPL-2.0
```
- Removed comments that link to the internal Bugzilla or Jira.