### PR TITLE
Updating the artifacts bundle image from stg to prod registry

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -1,6 +1,6 @@
 {
     "v1.24.9+vmware.1" : {
         "supported_os": ["photon-3", "ubuntu-2004-efi"],
-        "artifacts_image": "projects-stg.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1"
+        "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1"
     }
 }


### PR DESCRIPTION
Verified stage and prod images are the same

```
kosarajud@kosarajudDXJW3:~$ imgpkg tag resolve -i projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1
projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle@sha256:9dcec246657fa7cf5ece1feab6164e200c9bc82b359471bbdec197d028b8e577
Succeeded
kosarajud@kosarajudDXJW3:~$ imgpkg tag resolve -i projects-stg.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1
projects-stg.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle@sha256:9dcec246657fa7cf5ece1feab6164e200c9bc82b359471bbdec197d028b8e577
Succeeded
```
- Generated both Photon and Ubuntu Images
- Ran gce2e for both Photon and Ubuntu Images

Fixes #27 

Signed-off-by: Dimple Raja Vamsi Kosaraju <kosarajud@vmware.com>