### PR TITLE
[TKG]Support custom k8s image builder commit ID per supported Kubernetes version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ FROM photon:3.0
 ARG PACKER_VERSION=1.8.3
 ARG ANSIBLE_VERSION=2.11.5
 ARG IMAGE_BUILDER_REPO_NAME=image-builder
-# This is the upstream commit ID of the kubernetes image-builder (https://github.com/kubernetes-sigs/image-builder)
-ARG IMAGE_BUILDER_COMMIT_ID=1d4b0445b364712c3ab5d3c6f721b808fa0bfa2e
 
 ENV PATH=${PATH}:/ovftool
 
@@ -35,7 +33,6 @@ RUN unzip VMware-ovftool-4.4.3-18663434-lin.x86_64.zip -d /
 # Setup image Builder code
 RUN git clone https://github.com/kubernetes-sigs/image-builder.git
 WORKDIR $IMAGE_BUILDER_REPO_NAME
-RUN git checkout $IMAGE_BUILDER_COMMIT_ID
 
 # Running deps-ova to setup packer goss provisioner
 WORKDIR images/capi

--- a/build-ova.sh
+++ b/build-ova.sh
@@ -14,6 +14,13 @@ custom_ovf_properties_file=${image_builder_root}/custom_ovf_properties.json
 artifacts_output_folder=${image_builder_root}/artifacts
 ova_destination_folder=${artifacts_output_folder}/ovas
 
+function checkout_image_builder_branch() {
+    # Check out image builder with specific commit for the
+    # corresponding k8s version
+    cd ${image_builder_root}
+    git checkout ${IMAGE_BUILDER_COMMIT_ID}
+}
+
 function copy_custom_image_builder_files() {
     cp image/hack/tkgs-image-build-ova.py hack/image-build-ova.py
     cp image/hack/tkgs_ovf_template.xml hack/ovf_template.xml
@@ -87,6 +94,7 @@ function copy_ova() {
 }
 
 function main() {
+    checkout_image_builder_branch
     copy_custom_image_builder_files
     download_configuration_files
     generate_packager_configuration

--- a/hack/make-helpers/build-node-image.sh
+++ b/hack/make-helpers/build-node-image.sh
@@ -33,9 +33,12 @@ function build_node_image() {
 	-v $IMAGE_ARTIFACTS_PATH:/image-builder/images/capi/artifacts \
 	-w /image-builder/images/capi/ \
 	-e ARTIFACTS_CONTAINER_IP=$ARTIFACTS_CONTAINER_IP -e ARTIFACTS_CONTAINER_PORT=$ARTIFACTS_CONTAINER_PORT -e OS_TARGET=$OS_TARGET \
-	-e TKR_SUFFIX=$TKR_SUFFIX \
+	-e TKR_SUFFIX=$TKR_SUFFIX -e IMAGE_BUILDER_COMMIT_ID=$IMAGE_BUILDER_COMMIT_ID \
 	$BYOI_IMAGE_NAME
 }
+
+# Fetching Image Builder commit ID from supported-versions.json
+IMAGE_BUILDER_COMMIT_ID=$(jq -r '."'$KUBERNETES_VERSION'".extra_params.image_builder_commit' $SUPPORTED_VERSIONS_JSON)
 
 supported_os_list=$(jq -r '."'$KUBERNETES_VERSION'".supported_os' $SUPPORTED_VERSIONS_JSON)
 if [ "$supported_os_list" == "null" ]; then

--- a/supported-versions.json
+++ b/supported-versions.json
@@ -1,6 +1,9 @@
 {
     "v1.24.9+vmware.1" : {
         "supported_os": ["photon-3", "ubuntu-2004-efi"],
-        "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1"
+        "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1",
+        "extra_params": {
+            "image_builder_commit": "1d4b0445b364712c3ab5d3c6f721b808fa0bfa2e"
+        }
     }
 }


### PR DESCRIPTION
Currently, the image-builder commit ID is being set in the docker file to a static value, which remains constant regardless of the kubernetes version.
There may be some dependencies on the commit ID to be chosen as per the kubernetes version.

```
make build-node-image OS_TARGET=photon-3 KUBERNETES_VERSION=v1.24.9+vmware.1 TKR_SUFFIX=byoi ARTIFACTS_CONTAINER_IP=10.215.97.148 IMAGE_ARTIFACTS_PATH=/root/image_changes

sha256:50f80e611a6a9b407a4ae934bec77f1fc9f3ca62a1440bab555db4edb12ec42b
Using default port for artifacts container 8081
52d1ed2159d2c3466344dec767f274a877b9b7be2fc45a672122f0316bfffc7e

 Hint: Use "docker logs -f v1.24.9---vmware.1-photon-3-image-builder" to see logs and status
 Hint: Node Image OVA can be found at /root/image_changes/ovas/
```

With this change, the image-builder commit ID is made configurable according to the kubernetes version supported.
In the supported-versions.json, along with other key-value pairs, a new key-value pair for `image_builder_commit` is added.

Closes Issue : #13 

Testing Done:

```
make build-node-image OS_TARGET=photon-3 KUBERNETES_VERSION=v1.24.9+vmware.1 TKR_SUFFIX=byoi ARTIFACTS_CONTAINER_IP=10.215.97.148 IMAGE_ARTIFACTS_PATH=/root/image_changes
sha256:50f80e611a6a9b407a4ae934bec77f1fc9f3ca62a1440bab555db4edb12ec42b
Using default port for artifacts container 8081
52d1ed2159d2c3466344dec767f274a877b9b7be2fc45a672122f0316bfffc7e

 Hint: Use "docker logs -f v1.24.9---vmware.1-photon-3-image-builder" to see logs and status
 Hint: Node Image OVA can be found at /root/image_changes/ovas/
```

```
docker logs -f v1.24.9---vmware.1-photon-3-image-builder
git checkout -f 1d4b0445b364712c3ab5d3c6f721b808fa0bfa2e
Note: switching to '1d4b0445b364712c3ab5d3c6f721b808fa0bfa2e'.

HEAD is now at 1d4b0445b Merge pull request #1023 from DimpleRajaVamsi/max_min_packer_ports
```

Able to create TKC out of the newly created OVA

```
k get tkc -A
NAMESPACE   NAME   CONTROL PLANE   WORKER   TKR NAME                  AGE   READY   TKR COMPATIBLE   UPDATES AVAILABLE
tkg-byoi    utkc   1               1        v1.24.9---vmware.1-byoi   17m   True    True             [v1.24.9+vmware.1-prodimag]
```