### PR TITLE
Modify update_cbt function and remove --rm flag to support k8s 1.25.7

### DIFF
--- a/ansible/files/scripts/image_retag.py
+++ b/ansible/files/scripts/image_retag.py
@@ -96,7 +96,7 @@ class localRegistry():
     def __init__(self, dockerVersion):
         self.dockerVersion = dockerVersion
         self.ctrPrefix = "ctr -n k8s.io "
-        self.ctrRunOptions = "run -d --null-io --net-host --rm "
+        self.ctrRunOptions = "run -d --null-io --net-host "
 
         self.registryImage = f"docker.io/vmware/docker-registry:{self.dockerVersion}"
 

--- a/ansible/tasks/retag_images.yml
+++ b/ansible/tasks/retag_images.yml
@@ -7,7 +7,7 @@
     executable: python3
 
 - name: Start docker registry
-  shell: 'ctr -n k8s.io run -d --null-io --net-host --rm --mount type=bind,src=/storage/container-registry,dst=/var/lib/registry,options=rbind:rw docker.io/vmware/docker-registry:2.7.1 docker-registry /bin/registry serve /etc/docker/registry/config.yaml'
+  shell: 'ctr -n k8s.io run -d --null-io --net-host --mount type=bind,src=/storage/container-registry,dst=/var/lib/registry,options=rbind:rw docker.io/vmware/docker-registry:2.7.1 docker-registry /bin/registry serve /etc/docker/registry/config.yaml'
 
 - name: Copy carvel packages and images to Embedded registry
   script: files/scripts/utkg_download_carvel_packages.py --addonImageList {{ addon_image_list }} --addonLocalImageList {{ localhost_addon_image_list }}

--- a/scripts/tkg_byoi.py
+++ b/scripts/tkg_byoi.py
@@ -299,9 +299,10 @@ def update_cbt(cbt_file, cbt_name, old_tkr_name, new_tkr_name):
             cbt_data["spec"][addon]["valuesFrom"]["providerRef"]["name"].replace(old_tkr_name, new_tkr_name)
     for index in range(len(cbt_data["spec"]["additionalPackages"])):
         if "valuesFrom" in cbt_data["spec"]["additionalPackages"][index]:
-            cbt_data["spec"]["additionalPackages"][index]["valuesFrom"]["secretRef"] = \
-                cbt_data["spec"]["additionalPackages"][index]["valuesFrom"]["secretRef"].replace(old_tkr_name,
-                                                                                                 new_tkr_name)
+            if "secretRef" in cbt_data["spec"]["additionalPackages"][index]["valuesFrom"]:
+                cbt_data["spec"]["additionalPackages"][index]["valuesFrom"]["secretRef"] = \
+                    cbt_data["spec"]["additionalPackages"][index]["valuesFrom"]["secretRef"].replace(old_tkr_name,
+                                                                                                    new_tkr_name)
     with open(cbt_file, 'w') as fp:
         yaml.dump(cbt_data, fp)
     print("New CBT Name:", cbt_name)


### PR DESCRIPTION
This PR will bring in the following changes:
1. Modify update_cbt function to add a check before updating `secretRef` in ClusterBootstrapTemplate Config.
2. Remove the --rm flag from ctr functions , since --rm and --d flag cannot be used together for container version v1.16.8 and above.

Closes issue #36 

Testing Done:

1. Updated the artifacts bundle for 1.25.7
2. Validated creation of 1.25.7 OVA and creation of TKC
3. Validated the existing workflow for 1.24.9 OVA and creation of TKC out of it

Signed-off-by: Rida Zuber <ridaz@vmware.com>