### PR TITLE
Bump cloud init version, use systemd cgroup for containerd and disable cgroup kernel memory accounting

### DIFF
--- a/ansible/tasks/photon.yml
+++ b/ansible/tasks/photon.yml
@@ -34,3 +34,10 @@
     backrefs: yes
     regexp: "^(?!.*pos=1)(photon_cmdline.*)"
     line: '\1 pos=1'
+
+- name: Disabling cgroups kernel memory accounting and disabling cgroups v2
+  lineinfile:
+    path: /boot/photon.cfg
+    backrefs: yes
+    regexp: "^(photon_cmdline.*)$"
+    line: '\1 cgroup.memory=nokmem systemd.legacy_systemd_cgroup_controller=yes'

--- a/ansible/templates/etc/containerd/config_v2.toml
+++ b/ansible/templates/etc/containerd/config_v2.toml
@@ -35,7 +35,6 @@ oom_score = 0
     enable_selinux = false
     sandbox_image = "{{ pause_image }}"
     stats_collect_period = 10
-    systemd_cgroup = false
     enable_tls_streaming = false
     max_container_log_line_size = 16384
     disable_proc_mount = false
@@ -43,6 +42,11 @@ oom_score = 0
       snapshotter = "overlayfs"
       no_pivot = false
       default_runtime_name = "runc"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+         runtime_type = "io.containerd.runc.v2"
+         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+           SystemdCgroup = true
       [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
         runtime_type = ""
         runtime_engine = ""

--- a/scripts/utkg_custom_ovf_properties.py
+++ b/scripts/utkg_custom_ovf_properties.py
@@ -36,7 +36,7 @@ def set_versions(args):
     version_maps = {
         "image": kubernetes_config["image_version"],
         "k8s": kubernetes_config["kubernetes"],
-        "cloudInit": "19.4",
+        "cloudInit": "22.4.2",
         "coredns": kubernetes_config["coredns"],
         "etcd": kubernetes_config["etcd"],
     }


### PR DESCRIPTION
This PR has the below changes

- Bump the cloud-init version from 19.4 to 22.4.2
- Use systemd cgroup driver for containerd (Upstream already uses systemd cgroup driver for containerd)
- Disable cgroups kernel memory account and disable cgroups v2 for Photon (Photon grub command line changes)

All the above changes are applicable for both 1.24 and 1.25(In progress)

Fixes #42 

## Testing
- Built Photon/Ubuntu 1.24/1.25 Images
- gce2e for Photon 1.24.9 (gce2e#8926) 🟢 
- gce2e for Photon 1.25.7 (gce2e#8927) 🟢 
- gce2e for Ubuntu 1.24.9 (gce2e#8942) 🟢 
- gce2e for Ubuntu 1.25.7 (gce2e#8935) 🟢 
- Live cluster verification details
```
root@cc-2zbsx-n28qq [ ~ ]# cat /boot/photon.cfg
# GRUB Environment Block
photon_cmdline=init=/lib/systemd/systemd rcupdate.rcu_expedited=1 rw systemd.show_status=0 quiet noreplace-smp cpu_init_udelay=0 transparent_hugepage=madvise apparmor=1 pos=1 cgroup.memory=nokmem systemd.legacy_systemd_cgroup_controller=yes
photon_linux=vmlinuz-4.19.283-3.ph3-esx
photon_initrd=initrd.img-4.19.283-3.ph3-esx
root@cc-2zbsx-n28qq [ ~ ]# cat /etc/containerd/config.toml | grep SystemdCgroup
           SystemdCgroup = true
root@cc-2zbsx-n28qq [ ~ ]# cloud-init --version
/bin/cloud-init 22.4.2
```

Signed-off-by: Dimple Raja Vamsi Kosaraju <kosarajud@vmware.com>