### PR TITLE
Update supported-versions.json with k8s version 1.25.7

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -5,5 +5,12 @@
         "extra_params": {
             "image_builder_commit": "1d4b0445b364712c3ab5d3c6f721b808fa0bfa2e"
         }
+    },
+    "v1.25.7+vmware.3" : {
+        "supported_os": ["photon-3", "ubuntu-2004-efi"],
+        "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.25.7_vmware.3-fips.1-tkg.1",
+        "extra_params": {
+            "image_builder_commit": "1d4b0445b364712c3ab5d3c6f721b808fa0bfa2e"
+        }
     }
 }


### PR DESCRIPTION
Issue: #48 

This PR will add the support for TKR version 1.25.7 (Photon/Ubuntu) with the artifacts bundle image and image builder commit details.

```
 make list-versions
            Kubernetes Version  |  Supported OS
              v1.24.9+vmware.1  |  [photon-3,ubuntu-2004-efi]
              v1.25.7+vmware.3  |  [photon-3,ubuntu-2004-efi]

 Hint: Use "make run-artifacts-container KUBERNETES_VERSION=<version>" to run the artifacts container.

```