### PR TITLE
Adding GitHub Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+
+name: Bug report
+about: Tell us about a problem you are experiencing
+
+---
+
+<!--
+Thank you for the Bug report! Before submitting, please delete all of
+the HTML comments.
+-->
+
+**What steps did you take and what happened:**
+<!-- A clear and concise description of what the bug is. -->
+
+**What did you expect to happen:**
+<!-- Please describe what you expected the outcome to be. -->
+
+**Is there anything else you would like to add?**
+<!-- Miscellaneous information that will assist in solving the issue. -->
+
+**Please tell us about your environment.**
+
+<!-- Note: If any of information is not applicable add NA in the Value field. -->
+
+<table>
+<tr>
+<td></td>
+<th>Value</th>
+<th>How to Obtain</th>
+</tr>
+<tr>
+<th>Commit ID</th>
+<td><code><!-- Placeholder for the version --></code></td>
+<td>Run <code>git log -1</code></td>
+</tr>
+<tr>
+<th>Kubernetes Version</th>
+<td><code><!-- Placeholder for the version --></code></td>
+<td>Kubernetes version that you are trying to build the image</td>
+</tr>
+<tr>
+<th>OS Type</th>
+<td><code><!-- Placeholder for the version --></code></td>
+<td>OS Type and version that you are trying to build the image</td>
+</tr>
+</table>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!--
+Thank you for the feature request! Before submitting, please delete all of
+the HTML comments.
+-->
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe the solution you'd like**
+<!-- Miscellaneous information that will assist in solving the issue. -->
+
+**Additional context**
+<!-- Add any other context or screenshots or any alternative solutions
+considered about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+Thanks for sending a pull request! Before submitting, please delete all of
+the HTML comments.
+-->
+
+**What does this PR do, and why is it needed?**
+
+<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->
+
+**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+
+Fixes #
+
+**Testing Done**:
+<!-- Mention details of the testing done for validating this pull request / change -->
+
+**Are there any special notes for your reviewer**:
+
+<!-- Anything else you would like the reviewers to know about this PR. -->


### PR DESCRIPTION
## Changes
Adding GitHub Issue and PR templates.

Most of the template is copy paste from either [image-builder](https://github.com/kubernetes-sigs/image-builder/) or vm-operator](https://github.com/vmware-tanzu/vm-operator/) Issue/PR templates with some minor modification as required for vSphere TKG image builder.

To view the templates after rendering go to [`gh-issue-pr-tpl` branch](https://github.com/DimpleRajaVamsi/vsphere-tanzu-kubernetes-grid-image-builder/tree/gh-issue-pr-tpl/.github)

Fixes: #54 

Signed-off-by: Dimple Raja Vamsi Kosaraju <kosarajud@vmware.com>