### PR TITLE
Add 1.26.5 Support

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -12,5 +12,12 @@
         "extra_params": {
             "image_builder_commit": "e5c6813621e13b3efc0f5181241673006fa643d9"
         }
+    },
+    "v1.26.5+vmware.2-fips.1" : {
+        "supported_os": ["photon-3", "ubuntu-2004-efi"],
+        "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.26.5_vmware.2-fips.1-tkg.1",
+        "extra_params": {
+            "image_builder_commit": "e5c6813621e13b3efc0f5181241673006fa643d9"
+        }
     }
 }


### PR DESCRIPTION
Add 1.26.5 Support
**What does this PR do, and why is it needed?**
This PR will add the support for TKR version 1.25.7 (Photon/Ubuntu) with the artifacts bundle image and image builder commit details.

make list-versions
            Kubernetes Version  |  Supported OS
              v1.24.9+vmware.1  |  [photon-3,ubuntu-2004-efi]
       v1.25.7+vmware.3-fips.1  |  [photon-3,ubuntu-2004-efi]
       v1.26.5+vmware.2-fips.1  |  [photon-3,ubuntu-2004-efi]

**Which issue(s) is/are addressed by this PR?** *

Fixes #58 

**Testing Done**:
make list-versions
            Kubernetes Version  |  Supported OS
              v1.24.9+vmware.1  |  [photon-3,ubuntu-2004-efi]
       v1.25.7+vmware.3-fips.1  |  [photon-3,ubuntu-2004-efi]
       v1.26.5+vmware.2-fips.1  |  [photon-3,ubuntu-2004-efi]