### PR TITLE
Bump ansible version and download packer using deps-ova target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ MAKEFLAGS += -s
 .EXPORT_ALL_VARIABLES:
 
 # Default variables
-BYOI_IMAGE_NAME = vsphere-tanzu-byoi
 DEFAULT_ARTIFACTS_CONTAINER_PORT = 8081
 DEFAULT_PACKER_HTTP_PORT = 8082
 MAKE_HELPERS_PATH = $(shell pwd)/hack/make-helpers
@@ -57,8 +56,11 @@ define BUILD_IMAGE_BUILDER_CONTAINER_HELP_INFO
 # Will create a docker container image for creation of TKGs OVA with the dependencies
 # like packer, ansible and kubernetes image builder code.
 # 
+# Arguments:
+#   KUBERNETES_VERSION: [Required] kubernetes version of the artifacts containers, to see
+#                       list of supported kubernetes versions use "make list-versions".
 # Example:
-# make build-image-builder-container
+# make build-image-builder-container KUBERNETES_VERSION=v1.23.15+vmware.1
 endef
 .PHONY: build-image-builder-container
 ifeq ($(PRINT_HELP),y)
@@ -66,7 +68,7 @@ build-image-builder-container:
 	printf "$$green$$BUILD_IMAGE_BUILDER_CONTAINER_HELP_INFO$$clear\n"
 else
 build-image-builder-container:
-	docker build --platform=linux/amd64 -q -t $(BYOI_IMAGE_NAME) .
+	$(MAKE_HELPERS_PATH)/build-image-builder-container.sh
 endif
 
 define BUILD_NODE_IMAGE

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ make run-artifacts-container PRINT_HELP=y                                       
 make run-artifacts-container KUBERNETES_VERSION=v1.22.13+vmware.1 ARTIFACTS_CONTAINER_PORT=9090 # To run 1.22.13 Kubernetes artifacts container on port 9090
 ```
 
-- `make build-container` is used to build the image builder container locally with all the dependencies like `Packer`, `Ansible`, and `OVF Tool`.
+- `make build-image-builder-container` is used to build the image builder container locally with all the dependencies like `Packer`, `Ansible`, and `OVF Tool`.
 
 ```bash
 make build-image-builder-container PRINT_HELP=y # To show the help information for this target.
-make build-image-builder-container              # To create the image builder container.
+make build-image-builder-container KUBERNETES_VERSION=v1.23.15+vmware.1 # To create the image builder container.
 ```
 
 - `make build-node-image` is used to build the vSphere Tanzu compatible node image for a Kubernetes version.

--- a/build-ova.sh
+++ b/build-ova.sh
@@ -15,14 +15,6 @@ artifacts_output_folder=${image_builder_root}/artifacts
 ova_destination_folder=${artifacts_output_folder}/ovas
 photon3_stig_compliance="false"
 
-function checkout_image_builder_branch() {
-    # Check out image builder with specific commit for the
-    # corresponding k8s version
-    cd ${image_builder_root}
-    git pull
-    git checkout ${IMAGE_BUILDER_COMMIT_ID}
-}
-
 function copy_custom_image_builder_files() {
     cp image/hack/tkgs-image-build-ova.py hack/image-build-ova.py
     cp image/hack/tkgs_ovf_template.xml hack/ovf_template.xml
@@ -123,7 +115,6 @@ function copy_ova() {
 }
 
 function main() {
-    checkout_image_builder_branch
     copy_custom_image_builder_files
     download_configuration_files
     generate_packager_configuration

--- a/docs/examples/adding_os_pkg_repos.md
+++ b/docs/examples/adding_os_pkg_repos.md
@@ -31,7 +31,7 @@ _**Note**: If you are building just the Ubuntu OS node image you will not have t
 
 [kubernetes image builder][kubernetes-image-builder] provides `extra_repos` packer variables through which sources/repositories can be configured for both Photon and Ubuntu. As there is a difference in how Ubuntu/Photon sources are configured we need to have separate source files for Photon/Ubuntu.
 
-- Create new folder `repos` in [ansible files](./../../../ansible/files/) folder
+- Create new folder `repos` in [ansible files][ansible-files] folder
 - Create a new file for Photon sources called `photon.repo` in the `repos` folder. Refer below for sample content and refer to the official Photon [document][photon-repo-doc] for more information
 
 ```text
@@ -100,9 +100,9 @@ To remove the extra repositories/sources that were configured during the image b
 
 [//]: Links
 
-[ansible-files]: [./../../../ansible/files/]
+[ansible-files]: ./../../ansible/files/
 [customizations-doc]: https://image-builder.sigs.k8s.io/capi/capi.html#customization
-[default-args]: [./../../../packer-variables/default-args.j2]
+[default-args]: ./../../packer-variables/default-args.j2
 [jinja]: https://jinja.palletsprojects.com/en/3.1.x/
 [kubernetes-image-builder]: https://github.com/kubernetes-sigs/image-builder/
 [photon-repo-doc]: https://vmware.github.io/photon/assets/files/html/3.0/photon_admin/adding-a-new-repository.html

--- a/hack/make-helpers/build-image-builder-container.sh
+++ b/hack/make-helpers/build-image-builder-container.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+source $(dirname "${BASH_SOURCE[0]}")/utils.sh
+enable_debugging
+
+is_argument_set "KUBERNETES_VERSION argument is required" $KUBERNETES_VERSION
+
+
+docker_build_args=$(jq -r '."'$KUBERNETES_VERSION'".docker_build_args | keys[]' $SUPPORTED_VERSIONS_JSON)
+build_variables=""
+for docker_arg in $docker_build_args;
+do
+    docker_arg_value=$(jq -r '."'$KUBERNETES_VERSION'".docker_build_args."'$docker_arg'"' $SUPPORTED_VERSIONS_JSON)
+    build_variables="${build_variables} --build-arg ${docker_arg}=${docker_arg_value}"
+done
+
+# by default don't show docker output
+docker_debug_flags="-q"
+if [ ! -z ${DEBUGGING+x} ]; then
+    docker_debug_flags="--progress plain"
+fi 
+
+docker build --platform=linux/amd64 $docker_debug_flags \
+-t $(get_image_builder_container_image_name $KUBERNETES_VERSION) \
+$build_variables $(dirname "${BASH_SOURCE[0]}")/../../.

--- a/hack/make-helpers/build-node-image.sh
+++ b/hack/make-helpers/build-node-image.sh
@@ -41,15 +41,12 @@ function build_node_image() {
 	-v $IMAGE_ARTIFACTS_PATH:/image-builder/images/capi/artifacts \
 	-w /image-builder/images/capi/ \
 	-e HOST_IP=$HOST_IP -e ARTIFACTS_CONTAINER_PORT=$ARTIFACTS_CONTAINER_PORT -e OS_TARGET=$OS_TARGET \
-	-e TKR_SUFFIX=$TKR_SUFFIX -e IMAGE_BUILDER_COMMIT_ID=$IMAGE_BUILDER_COMMIT_ID -e KUBERNETES_VERSION=$KUBERNETES_VERSION \
+	-e TKR_SUFFIX=$TKR_SUFFIX -e KUBERNETES_VERSION=$KUBERNETES_VERSION \
 	-e PACKER_HTTP_PORT=$PACKER_HTTP_PORT \
 	-p $PACKER_HTTP_PORT:$PACKER_HTTP_PORT \
 	--platform linux/amd64 \
-	$BYOI_IMAGE_NAME
+	$(get_image_builder_container_image_name $KUBERNETES_VERSION)
 }
-
-# Fetching Image Builder commit ID from supported-versions.json
-IMAGE_BUILDER_COMMIT_ID=$(jq -r '."'$KUBERNETES_VERSION'".extra_params.image_builder_commit' $SUPPORTED_VERSIONS_JSON)
 
 supported_os_list=$(jq -r '."'$KUBERNETES_VERSION'".supported_os' $SUPPORTED_VERSIONS_JSON)
 if [ "$supported_os_list" == "null" ]; then

--- a/hack/make-helpers/utils.sh
+++ b/hack/make-helpers/utils.sh
@@ -51,3 +51,14 @@ function get_node_image_builder_container_labels() {
     os_target=$2
     echo "-l byoi -l byoi_image_builder -l $kubernetes_version -l $os_target"
 }
+
+function get_image_builder_container_image_name() {
+    kubernetes_version=$1
+    default_image_name="vsphere-tanzu-byoi"
+    image_name=$default_image_name
+
+    # Docker image name doesn't support `+` so replace them with `---`
+    kubernetes_version=${kubernetes_version//+/---}
+    image_name=$image_name-$kubernetes_version
+    echo "$image_name"
+}

--- a/supported-versions.json
+++ b/supported-versions.json
@@ -1,23 +1,32 @@
 {
-    "v1.24.9+vmware.1" : {
-        "supported_os": ["photon-3", "ubuntu-2004-efi"],
+    "v1.24.9+vmware.1": {
+        "supported_os": [
+            "photon-3",
+            "ubuntu-2004-efi"
+        ],
         "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1",
-        "extra_params": {
-            "image_builder_commit": "e5c6813621e13b3efc0f5181241673006fa643d9"
+        "docker_build_args": {
+            "IMAGE_BUILDER_COMMIT_ID": "e5c6813621e13b3efc0f5181241673006fa643d9"
         }
     },
-    "v1.25.7+vmware.3-fips.1" : {
-        "supported_os": ["photon-3", "ubuntu-2004-efi"],
+    "v1.25.7+vmware.3-fips.1": {
+        "supported_os": [
+            "photon-3",
+            "ubuntu-2004-efi"
+        ],
         "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.25.7_vmware.3-fips.1-tkg.1",
-        "extra_params": {
-            "image_builder_commit": "e5c6813621e13b3efc0f5181241673006fa643d9"
+        "docker_build_args": {
+            "IMAGE_BUILDER_COMMIT_ID": "e5c6813621e13b3efc0f5181241673006fa643d9"
         }
     },
-    "v1.26.5+vmware.2-fips.1" : {
-        "supported_os": ["photon-3", "ubuntu-2004-efi"],
+    "v1.26.5+vmware.2-fips.1": {
+        "supported_os": [
+            "photon-3",
+            "ubuntu-2004-efi"
+        ],
         "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.26.5_vmware.2-fips.1-tkg.1",
-        "extra_params": {
-            "image_builder_commit": "e5c6813621e13b3efc0f5181241673006fa643d9"
+        "docker_build_args": {
+            "IMAGE_BUILDER_COMMIT_ID": "e5c6813621e13b3efc0f5181241673006fa643d9"
         }
     }
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
With https://github.com/vmware-tanzu/vsphere-tanzu-kubernetes-grid-image-builder/pull/33 git checkout will happen during the image build process and recently there has been a change in the upstream(https://github.com/kubernetes-sigs/image-builder/commit/a299f46009691d65a8b0505c85e92084d107b320) that bumps Ansible and changes the minimum supported Python version to 3.9.

We use [Photon 3.0](https://github.com/vmware-tanzu/vsphere-tanzu-kubernetes-grid-image-builder/blob/main/Dockerfile#L4) in the container image and it only supports 3.7. Ideally, we shouldn't be syncing the code to the latest we should be syncing the code the `image-builder-commit-id` that has been tested during the build process so that we will not hit any issues with `make deps-ova`.

While making the above change hit this Ansible issue https://github.com/ansible/ansible/issues/81830#issuecomment-1743199288 where I had to bump the Ansible version.

As I have to bump the ansible version, I also have to bump the Python version which in turn requires me to bump the Photon version to 4.0.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #69 

**Testing Done**:
- Generated six images
```
root@ubuntuguest:~/ova/ovas# tree .
.
├── photon-3-amd64-v1.24.9---vmware.1-ansible.ova
├── photon-3-amd64-v1.25.7---vmware.3-fips.1-ansible.ova
├── photon-3-amd64-v1.26.5---vmware.2-fips.1-ansible.ova
├── ubuntu-2004-amd64-v1.24.9---vmware.1-ansible.ova
├── ubuntu-2004-amd64-v1.25.7---vmware.3-fips.1-ansible.ova
└── ubuntu-2004-amd64-v1.26.5---vmware.2-fips.1-ansible.ova
```
- Verified cluster creation for all the above TKRs.

**Are there any special notes for your reviewer**:
Other changes include
- Some doc updates that have invalid links
- Removed dependency on the packer version. (Packer will be installed using the `make deps-ova`)
- Any key inside `docker_build_args` will be passed as a docker build argument.