### PR TITLE
Update the registry to pull artifact images from new registry location for broadcom

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -4,7 +4,7 @@
             "photon-3",
             "ubuntu-2004-efi"
         ],
-        "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1",
+        "artifacts_image": "projects.packages.broadcom.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1",
         "docker_build_args": {
             "IMAGE_BUILDER_COMMIT_ID": "e5c6813621e13b3efc0f5181241673006fa643d9"
         }
@@ -14,7 +14,7 @@
             "photon-3",
             "ubuntu-2004-efi"
         ],
-        "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.25.7_vmware.3-fips.1-tkg.1",
+        "artifacts_image": "projects.packages.broadcom.com/tkg/tkg-vsphere-linux-resource-bundle:v1.25.7_vmware.3-fips.1-tkg.1",
         "docker_build_args": {
             "IMAGE_BUILDER_COMMIT_ID": "e5c6813621e13b3efc0f5181241673006fa643d9"
         }
@@ -24,7 +24,7 @@
             "photon-3",
             "ubuntu-2004-efi"
         ],
-        "artifacts_image": "projects.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.26.5_vmware.2-fips.1-tkg.1",
+        "artifacts_image": "projects.packages.broadcom.com/tkg/tkg-vsphere-linux-resource-bundle:v1.26.5_vmware.2-fips.1-tkg.1",
         "docker_build_args": {
             "IMAGE_BUILDER_COMMIT_ID": "e5c6813621e13b3efc0f5181241673006fa643d9"
         }


### PR DESCRIPTION
With decomissioning of projects.registry.vmware.com, we need to update the location from where the artifat images will be pulled

✅ Closes: #75

