### PR TITLE
Blacklist nouveau driver to avoid conflict with nvidia GPU driver

### DIFF
--- a/ansible/defaults/main.yml
+++ b/ansible/defaults/main.yml
@@ -9,3 +9,9 @@ photon_va_hardening_url: "{{ artifacts_container_url }}/artifacts/photon_hardeni
 va_hardening_rpm_version: "3.0"
 va_hardening_rpm_release: "{{ imageVersion }}"
 carvel_tools: "/tmp/carvel-tools"
+systemd_networkd_update_initramfs: >-
+  {%- if ansible_os_family == 'VMware Photon OS' -%}
+  dracut -f
+  {%- elif ansible_os_family == 'Debian' -%}
+  update-initramfs -u
+  {%- endif -%}

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -159,3 +159,15 @@
   ansible.builtin.shell: K14SIO_INSTALL_BIN_DIR={{ carvel_tools }} /tmp/install.sh
   args:
     executable: /bin/bash
+
+
+- name: Unload nouveau
+  template:
+    src: "etc/modprobe.d/blacklist-nouveau.conf"
+    dest: "/etc/modprobe.d/blacklist-nouveau.conf"
+    mode: 0644
+  ignore_errors: true
+
+- name: Update initramfs
+  command: "{{ systemd_networkd_update_initramfs }}"
+  when: (systemd_networkd_update_initramfs is defined) and (systemd_networkd_update_initramfs | length > 0)

--- a/ansible/templates/etc/modprobe.d/blacklist-nouveau.conf
+++ b/ansible/templates/etc/modprobe.d/blacklist-nouveau.conf
@@ -1,0 +1,7 @@
+# blacklist nouveau -- keeps it from being loaded
+blacklist nouveau
+# options nouveau modeset=0 -- If the module is built into the kernel, then this disables it
+# This is to more like future-proofing against future kernels
+options nouveau modeset=0
+#Prevent from loading even when tried to be loaded (either manual or using some other instrument)
+install nouveau /bin/false


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

By default the supported OS  auto-loads the nouveau driver when it detects Nvidia GPU hardware. The nouveau driver sometimes conflicts with the nvidia proprietary driver that gpu-operator installs. So we need to blacklist it to prevent from auto-loading during boot and also block loading when anyother entity tries to load it.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Testing Done**:
Manually built  TKr version v1.27.11+vmware.1-fips.1 ubuntu ova and verified the following

blacklist config file present in location (/etc/modprobe.d/blacklist-nouveau.conf) along with proper contents
Using lsmod (sudo lsmod | grep nouveau) to validate nouveau module is not getting loaded by default at boot up by the kernel