### PR TITLE
Fix package discovery logic for gateway-api package

### DIFF
--- a/scripts/tkg_byoi.py
+++ b/scripts/tkg_byoi.py
@@ -102,12 +102,18 @@ def populate_jinja_args(args):
         kubernetes_args = json.loads(fp.read())
     jinja_args_map.update(kubernetes_args)
     jinja_args_map["kubernetes_version"] = jinja_args_map["kubernetes"]
-    jinja_args_map["kubernetes_series"] = jinja_args_map["kubernetes"].split('+')[0]
+    kubernetes_series = jinja_args_map["kubernetes"].split('+')[0]
+    jinja_args_map["kubernetes_series"] = kubernetes_series
+
+    if kubernetes_series.startswith("v"):
+        # Remove the leading v from version for semver module.
+        kubernetes_series = kubernetes_series[1:]
 
     # gateway-api package is not present for TKRs upto v1.26.x. gateway_package_present can be used
     # to determine if carvel package of gateway-api should be present depending on TKR version.
-    jinja_args_map["gateway_package_present"] = jinja_args_map["kubernetes_series"] > "v1.26"
-
+    jinja_args_map["gateway_package_present"] = False
+    if semver.compare(kubernetes_series, "1.26.5"):
+        jinja_args_map["gateway_package_present"] = True
     # Set STIG compliant value
     jinja_args_map["photon3_stig_compliance"] = "false"
     if args.os_type == "photon-3":


### PR DESCRIPTION
Currently gateway-api package is included in the list of addon packages to be installed regardless of TKR version. It should not be installed on TKR versions <v1.27 as gateway package is not available on these versions.

<!--
Thanks for sending a pull request! Before submitting, please delete all of
the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Testing Done**:
<!-- Mention details of the testing done for validating this pull request / change -->

**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->