### PR TITLE
Add support for building 1.28.8 images

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -1,14 +1,4 @@
 {
-    "v1.25.7+vmware.3-fips.1": {
-        "supported_os": [
-            "photon-3",
-            "ubuntu-2004-efi"
-        ],
-        "artifacts_image": "projects.packages.broadcom.com/tkg/tkg-vsphere-linux-resource-bundle:v1.25.7_vmware.3-fips.1-tkg.1",
-        "docker_build_args": {
-            "IMAGE_BUILDER_COMMIT_ID": "e5c6813621e13b3efc0f5181241673006fa643d9"
-        }
-    },
     "v1.26.5+vmware.2-fips.1": {
         "supported_os": [
             "photon-3",
@@ -27,6 +17,16 @@
         "artifacts_image": "projects.packages.broadcom.com/tkg/tkg-vsphere-linux-resource-bundle:v1.27.11_vmware.1-fips.1-tkg.2",
         "docker_build_args": {
             "IMAGE_BUILDER_COMMIT_ID": "cb925047f388090a0db3430ca3172da63eff952c"
+        }
+    },
+    "v1.28.8+vmware.1-fips.1": {
+        "supported_os": [
+            "photon-5",
+            "ubuntu-2204-efi"
+        ],
+        "artifacts_image": "projects.packages.broadcom.com/tkg/tkg-vsphere-linux-resource-bundle:v1.28.8_vmware.1-fips.1-tkg.2",
+        "docker_build_args": {
+            "IMAGE_BUILDER_COMMIT_ID": "d89cd8eee2e28bd77f138e7cb09869ff33ca7d5e"
         }
     }
 }


### PR DESCRIPTION


**What does this PR do, and why is it needed?**
* Add support for building 1.28.8 images
* Removes support for building 1.25.7 images


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
* Adds support for building Photon-5 based CAPI images (Supported only with v1.28.8 TKR)
