### PR TITLE
Add support for building 1.29.4 images

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -28,5 +28,15 @@
         "docker_build_args": {
             "IMAGE_BUILDER_COMMIT_ID": "d89cd8eee2e28bd77f138e7cb09869ff33ca7d5e"
         }
-    }
+    },
+    "v1.29.4+vmware.3-fips.1": {
+       "supported_os": [
+           "photon-5",
+           "ubuntu-2204-efi"
+       ],
+       "artifacts_image": "projects.packages.broadcom.com/tkg/tkg-vsphere-linux-resource-bundle:v1.29.4_vmware.3-fips.1-tkg.1",
+       "docker_build_args": {
+           "IMAGE_BUILDER_COMMIT_ID": "d89cd8eee2e28bd77f138e7cb09869ff33ca7d5e"
+       }
+   }
 }


### PR DESCRIPTION
What does this PR do, and why is it needed?

    Add support for building 1.29.4 images

Which issue(s) is/are addressed by this PR? (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

    Adds support for building Photon-5 based CAPI images (Supported only with v1.29.4 TKR)