### PR TITLE
Remove duplicate argument goss_inspect_mode for Windows build

### DIFF
--- a/packer-variables/windows/default-args-windows.j2
+++ b/packer-variables/windows/default-args-windows.j2
@@ -15,7 +15,6 @@
   "create_snapshot": "false",
   "disable_hypervisor": "false",
   "disk_size": "40960",
-  "goss_inspect_mode": "false",
   "kubernetes_base_url": "http://{{ host_ip }}:{{ artifacts_container_port }}/artifacts/{{ kubernetes_version }}/bin/windows/amd64",
   "kubernetes_series": "{{ kubernetes_series }}",
   "kubernetes_semver": "{{ kubernetes_version }}",


### PR DESCRIPTION
Remove a duplicate argument from `default-args-windows.j2` which is set in both `default-args-windows.j2` and `goss-args-windows.j2`