### PR TITLE
Update to latest upstream IB commit for windows fixes

### DIFF
--- a/supported-context.json
+++ b/supported-context.json
@@ -6,6 +6,6 @@
     ],
     "artifacts_image": "projects.packages.broadcom.com/vsphere/iaas/kubernetes-release/1.32.0/vkr-artifact-server:v1.32.0_vmware.6-fips-vkr.2",
     "docker_build_args": {
-        "IMAGE_BUILDER_COMMIT_ID": "49377913fe89429542805fd809ca1eabd5a93743"
+        "IMAGE_BUILDER_COMMIT_ID": "826a2d7e05288b72870ae45797e9d64efc101d07"
     }
 }


### PR DESCRIPTION
Update to the latest image builder commit to include fixes for windows credentials(allow customer to bootstrap password for administrator).