### PR TITLE
Fix the artifact server bundle tag

### DIFF
--- a/supported-context.json
+++ b/supported-context.json
@@ -3,7 +3,7 @@
         "photon-5",
         "ubuntu-2204-efi"
     ],
-    "artifacts_image": "projects.packages.broadcom.com/vsphere/iaas/kubernetes-release/1.30.14/tkg-vsphere-linux-resource-bundle:v1.30.14+vmware.1-fips-vkr.3",
+    "artifacts_image": "projects.packages.broadcom.com/vsphere/iaas/kubernetes-release/1.30.14/tkg-vsphere-linux-resource-bundle:v1.30.14_vmware.1-fips-vkr.3",
     "docker_build_args": {
         "IMAGE_BUILDER_COMMIT_ID": "49377913fe89429542805fd809ca1eabd5a93743"
     }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR fixes the wrong tag of the container image pushed in PR !113

Fixes #
No issues reported

**Testing Done**:
```
crane digest projects.packages.broadcom.com/vsphere/iaas/kubernetes-release/1.30.14/tkg-vsphere-linux-resource-bundle:v1.30.14_vmware.1-fips-vkr.3
sha256:0f1288a394d3ef532288cbba2b1be4fcce96dd91e84a10e492a828cb271e68ee
```